### PR TITLE
LIBFCREPO-1556: Replacing HTTPBearerAuth with JWTSecretAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ OAI_NAMESPACE_IDENTIFIER=...
 OAI_REPOSITORY_NAME=...
 # earliest datestamp of items in this repository
 EARLIEST_DATESTAMP=2014-01-01T00:00:00Z
-# JWT bearer token for accessing the Fedora repository
-FCREPO_JWT_TOKEN=...
+# JWT SECRET for the server to generate its own token to access the Fedora repository
+JWT_SECRET=...
 # URL to the Solr core to search
 SOLR_URL=...
 # enable debugging and hot reloading when run via "flask run"
@@ -142,7 +142,7 @@ docker run -d -p 5000:5000 \
     -e OAI_NAMESPACE_IDENTIFIER=... \
     -e OAI_REPOSITORY_NAME=... \
     -e EARLIEST_DATESTAMP=2014-01-01T00:00:00Z \
-    -e FCREPO_JWT_TOKEN=... \
+    -e JWT_SECRET=... \
     -e SOLR_URL=... \
     docker.lib.umd.edu/oaipmh-server:latest
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ the queries and fields it uses when making Solr requests.
 | `BASE_URL`                 | http://localhost:5000/ |
 | `DATESTAMP_GRANULARITY`    | YYYY-MM-DDThh:mm:ssZ   |
 | `EARLIEST_DATESTAMP`       |                        |
-| `FCREPO_JWT_TOKEN`         |                        |
+| `JWT_SECRET`               |                        |
 | `OAI_NAMESPACE_IDENTIFIER` |                        |
 | `OAI_REPOSITORY_NAME`      |                        |
 | `PAGE_SIZE`                | 25                     |
@@ -49,9 +49,9 @@ The earliest datestamp for which metadata or records can be retrieved.
 
 See also: [OAI-PMH Specification § 4.2 Identify]
 
-### `FCREPO_JWT_TOKEN`
+### `JWT_SECRET`
 
-JWT authentication token for requests to the fcrepo repository.
+JWT secret for the server to generate its own token to access the fcrepo repository.
 
 ### `OAI_NAMESPACE_IDENTIFIER`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "python-dotenv",
     "PyYAML",
     "requests",
-    "requests-jwtauth@git+https://github.com/umd-lib/requests-jwtauth.git@1.0.0",
+    "requests-jwtauth",
     "waitress",
     "Sickle"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pysolr==3.9.0
 python-dotenv==1.0.0
 PyYAML==6.0
 requests==2.31.0
-requests-jwtauth @ git+https://github.com/umd-lib/requests-jwtauth.git@1.0.0
+requests-jwtauth==1.0.1
 six==1.16.0
 urllib3==2.0.2
 validators==0.22.0

--- a/src/oaipmh/dataprovider.py
+++ b/src/oaipmh/dataprovider.py
@@ -159,10 +159,12 @@ class DataProvider(DataInterface):
 
 
 class FedoraDataProvider(DataProvider):
+    secret = EnvAttribute('JWT_SECRET')
+
     def __init__(self, index: Index):
         super().__init__(index)
         self.session.auth = JWTSecretAuth(
-            secret=environ.get('JWT_SECRET'),
+            secret=self.secret,
             claims={
                 'sub': 'umd-oaipmh-server',
                 'iss': 'umd-oaipmh-server',

--- a/src/oaipmh/dataprovider.py
+++ b/src/oaipmh/dataprovider.py
@@ -4,13 +4,21 @@ from enum import Enum
 from os import environ
 
 from lxml import etree
+
 # noinspection PyProtectedMember
 from lxml.etree import _Element
-from oai_repo import MetadataFormat, DataInterface, Identify, RecordHeader, Set, OAIRepoExternalException
+from oai_repo import (
+    DataInterface,
+    Identify,
+    MetadataFormat,
+    OAIRepoExternalException,
+    RecordHeader,
+    Set,
+)
 from oai_repo.exceptions import OAIErrorCannotDisseminateFormat
 from oai_repo.helpers import granularity_format
 from requests import Session
-from requests_jwtauth import HTTPBearerAuth
+from requests_jwtauth import JWTSecretAuth
 
 from oaipmh.oai import OAIIdentifier
 from oaipmh.solr import Index
@@ -153,7 +161,13 @@ class DataProvider(DataInterface):
 class FedoraDataProvider(DataProvider):
     def __init__(self, index: Index):
         super().__init__(index)
-        self.session.auth = HTTPBearerAuth(environ.get('FCREPO_JWT_TOKEN'))
+        self.session.auth = JWTSecretAuth(
+            secret=environ.get('JWT_SECRET'),
+            claims={
+                'sub': 'umd-oaipmh-server',
+                'iss': 'umd-oaipmh-server',
+                'role': 'fedoraAdmin'
+            })
 
     def get_record_metadata(self, identifier: str, metadataprefix: str) -> _Element | None:
         uri = self.get_uri(identifier)

--- a/tests/dataprovider/test_dataprovider.py
+++ b/tests/dataprovider/test_dataprovider.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
 from lxml import etree
@@ -11,6 +12,7 @@ from oaipmh.oai import OAIIdentifier
 from oaipmh.solr import Index, DEFAULT_SOLR_CONFIG
 
 environ['DATA_PROVIDER_TYPE'] = 'fedora'
+environ['JWT_SECRET'] = str(uuid4())
 
 
 @pytest.fixture


### PR DESCRIPTION
So that the server can generate it's own token
Also updated the pyproject to the package from PYPI instead of git

https://umd-dit.atlassian.net/browse/LIBFCREPO-1556